### PR TITLE
Protect the use of document to resolve SSR issues.

### DIFF
--- a/js/lib/dom.js
+++ b/js/lib/dom.js
@@ -1,4 +1,4 @@
-var range = null;
+let range = null;
 
 export function parseHTML(html) {
   if (range == null) { range = document.createRange() }

--- a/js/lib/dom.js
+++ b/js/lib/dom.js
@@ -1,6 +1,7 @@
-const range = document.createRange();
+var range = null;
 
 export function parseHTML(html) {
+  if (range == null) { range = document.createRange() }
   return range.createContextualFragment(html);
 }
 


### PR DESCRIPTION
To enable inclusion in applications that *may also use* SSR, the invocation of `document.createRange()` needs to be moved out of the global scope. Moving it into the `parseHTML()` method resolves this issue since it will only be executed if the component is actually used (on the browser side).

Full inclusion of this component by flowbite 2.4.0 introduced SSR-related bugs across multiple frameworks (Nuxt, NextJS, Sveltekit) due to this unprotected use of `document`.

Prior to flowbite 2.4.0, flowbite-datepicker was included via a "plugin" approach that mitigated this unprotected use of `document`,

This resolves issue #41