### PR TITLE
Mark dist/ as generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/dist/** linguist-generated


### PR DESCRIPTION
> Excluded from stats, hidden in diffs

https://github.com/github-linguist/linguist/blob/main/docs/overrides.md#summary

influences
![image](https://github.com/user-attachments/assets/19a1d437-4972-4349-b0f7-0a13e04d3808)

Please consider building dist/ files in a workflow that uploads it to npm.
https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages
